### PR TITLE
Add LinkBuilder.disableSuffixSelector to allow to diable the automatic addition of a "suffix" selector in case a suffix is present.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,11 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.9.4" date="not released">
+    <release version="1.10.0" date="not released">
+      <action type="add" dev="sseifert">
+        Add LinkBuilder.disableSuffixSelector to allow to diable the automatic addition of a "suffix" selector in case a suffix is present.
+        Although recommended as best practice, this can be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk for file name clashes in dispatcher cache.
+      </action>
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.7 as minimum version.
       </action>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.handler.link</artifactId>
-  <version>1.9.3-SNAPSHOT</version>
+  <version>1.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Link Handler</name>
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.handler.url</artifactId>
-      <version>1.7.0</version>
+      <version>1.10.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/wcm/handler/link/LinkArgs.java
+++ b/src/main/java/io/wcm/handler/link/LinkArgs.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
+import io.wcm.handler.url.UrlHandler;
 import io.wcm.handler.url.UrlMode;
 import io.wcm.wcm.commons.util.ToStringStyle;
 
@@ -50,9 +51,11 @@ public final class LinkArgs implements Cloneable {
   private String queryString;
   private String fragment;
   private String windowTarget;
+  private boolean disableSuffixSelector;
   private ValueMap properties;
   private String[] linkTargetUrlFallbackProperty;
   private String[] linkTargetWindowTargetFallbackProperty;
+
 
   /**
    * @return URL mode for externalizing the URL
@@ -199,6 +202,30 @@ public final class LinkArgs implements Cloneable {
   }
 
   /**
+   * Disable the automatic addition of an additional selector {@link UrlHandler#SELECTOR_SUFFIX}
+   * in case a suffix is present for building the URL. Although recommended as best practice, this can
+   * be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk
+   * for file name clashes in dispatcher cache.
+   * @return If set to true, no additional suffix selector is added
+   */
+  public boolean isDisableSuffixSelector() {
+    return this.disableSuffixSelector;
+  }
+
+  /**
+   * Disable the automatic addition of an additional selector {@link UrlHandler#SELECTOR_SUFFIX}
+   * in case a suffix is present for building the URL. Although recommended as best practice, this can
+   * be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk
+   * for file name clashes in dispatcher cache.
+   * @param value If set to true, no additional suffix selector is added
+   * @return this
+   */
+  public @NotNull LinkArgs disableSuffixSelector(boolean value) {
+    this.disableSuffixSelector = value;
+    return this;
+  }
+
+  /**
    * Custom properties that my be used by application-specific markup builders or processors.
    * @param map Property map. Is merged with properties already set.
    * @return this
@@ -314,6 +341,7 @@ public final class LinkArgs implements Cloneable {
     clone.queryString = this.queryString;
     clone.fragment = this.fragment;
     clone.windowTarget = this.windowTarget;
+    clone.disableSuffixSelector = this.disableSuffixSelector;
     clone.linkTargetUrlFallbackProperty = ArrayUtils.clone(this.linkTargetUrlFallbackProperty);
     clone.linkTargetWindowTargetFallbackProperty = ArrayUtils.clone(this.linkTargetWindowTargetFallbackProperty);
     if (this.properties != null) {

--- a/src/main/java/io/wcm/handler/link/LinkBuilder.java
+++ b/src/main/java/io/wcm/handler/link/LinkBuilder.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
 import io.wcm.handler.commons.dom.Anchor;
+import io.wcm.handler.url.UrlHandler;
 import io.wcm.handler.url.UrlMode;
 
 /**
@@ -87,6 +88,17 @@ public interface LinkBuilder {
    */
   @NotNull
   LinkBuilder windowTarget(@Nullable String windowTarget);
+
+  /**
+   * Disable the automatic addition of an additional selector {@link UrlHandler#SELECTOR_SUFFIX}
+   * in case a suffix is present for building the URL. Although recommended as best practice, this can
+   * be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk
+   * for file name clashes in dispatcher cache.
+   * @param disableSuffixSelector If set to true, no additional suffix selector is added
+   * @return URL builder
+   */
+  @NotNull
+  LinkBuilder disableSuffixSelector(boolean disableSuffixSelector);
 
   /**
    * Set URL mode for externalizing the URL

--- a/src/main/java/io/wcm/handler/link/impl/LinkBuilderImpl.java
+++ b/src/main/java/io/wcm/handler/link/impl/LinkBuilderImpl.java
@@ -206,6 +206,12 @@ final class LinkBuilderImpl implements LinkBuilder {
   }
 
   @Override
+  public @NotNull LinkBuilder disableSuffixSelector(boolean disableSuffixSelector) {
+    this.linkArgs.disableSuffixSelector(disableSuffixSelector);
+    return this;
+  }
+
+  @Override
   @SuppressFBWarnings("NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION")
   public @NotNull LinkBuilder linkTargetUrlFallbackProperty(@NotNull String @Nullable... propertyNames) {
     this.linkArgs.linkTargetUrlFallbackProperty(propertyNames);

--- a/src/main/java/io/wcm/handler/link/package-info.java
+++ b/src/main/java/io/wcm/handler/link/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Link Handler API.
  */
-@org.osgi.annotation.versioning.Version("1.6.0")
+@org.osgi.annotation.versioning.Version("1.7.0")
 package io.wcm.handler.link;

--- a/src/main/java/io/wcm/handler/link/type/helpers/InternalLinkResolver.java
+++ b/src/main/java/io/wcm/handler/link/type/helpers/InternalLinkResolver.java
@@ -197,6 +197,7 @@ public final class InternalLinkResolver {
           .queryString(queryString)
           .fragment(fragment)
           .urlMode(linkArgs.getUrlMode())
+          .disableSuffixSelector(linkArgs.isDisableSuffixSelector())
           .buildExternalLinkUrl(targetPage);
     }
 

--- a/src/test/java/io/wcm/handler/link/LinkArgsTest.java
+++ b/src/test/java/io/wcm/handler/link/LinkArgsTest.java
@@ -47,6 +47,7 @@ class LinkArgsTest {
         .queryString("query1")
         .fragment("fragment1")
         .windowTarget("_parent")
+        .disableSuffixSelector(true)
         .linkTargetUrlFallbackProperty("property1");
 
     assertEquals(UrlModes.FULL_URL, linkArgs.getUrlMode());
@@ -58,6 +59,7 @@ class LinkArgsTest {
     assertEquals("query1", linkArgs.getQueryString());
     assertEquals("fragment1", linkArgs.getFragment());
     assertEquals("_parent", linkArgs.getWindowTarget());
+    assertTrue(linkArgs.isDisableSuffixSelector());
     assertArrayEquals(new String[] { "property1" }, linkArgs.getLinkTargetUrlFallbackProperty());
   }
 
@@ -92,6 +94,7 @@ class LinkArgsTest {
         .windowTarget("_blank")
         .linkTargetUrlFallbackProperty("property1")
         .linkTargetWindowTargetFallbackProperty("property2")
+        .disableSuffixSelector(true)
         .properties(props);
 
     LinkArgs clone = linkArgs.clone();
@@ -105,6 +108,7 @@ class LinkArgsTest {
     assertEquals(linkArgs.getQueryString(), clone.getQueryString());
     assertEquals(linkArgs.getFragment(), clone.getFragment());
     assertEquals(linkArgs.getWindowTarget(), clone.getWindowTarget());
+    assertEquals(linkArgs.isDisableSuffixSelector(), clone.isDisableSuffixSelector());
     assertArrayEquals(linkArgs.getLinkTargetUrlFallbackProperty(), clone.getLinkTargetUrlFallbackProperty());
     assertArrayEquals(linkArgs.getLinkTargetWindowTargetFallbackProperty(), clone.getLinkTargetWindowTargetFallbackProperty());
     assertEquals(ImmutableValueMap.copyOf(linkArgs.getProperties()), ImmutableValueMap.copyOf(clone.getProperties()));

--- a/src/test/java/io/wcm/handler/link/LinkRequestTest.java
+++ b/src/test/java/io/wcm/handler/link/LinkRequestTest.java
@@ -30,7 +30,7 @@ class LinkRequestTest {
   @Test
   void testToString() {
     LinkRequest request = new LinkRequest(null, null, new LinkArgs().urlMode(UrlModes.DEFAULT));
-    assertEquals("LinkRequest[linkArgs=LinkArgs[urlMode=DEFAULT,dummyLink=false]]", request.toString());
+    assertEquals("LinkRequest[linkArgs=LinkArgs[urlMode=DEFAULT,dummyLink=false,disableSuffixSelector=false]]", request.toString());
   }
 
 }

--- a/src/test/java/io/wcm/handler/link/LinkTest.java
+++ b/src/test/java/io/wcm/handler/link/LinkTest.java
@@ -109,7 +109,7 @@ class LinkTest {
 
   @Test
   void testToString() {
-    assertEquals("Link[linkType=linkType,linkRequest=LinkRequest[linkArgs=LinkArgs[dummyLink=false]],linkReferenceInvalid=false]",
+    assertEquals("Link[linkType=linkType,linkRequest=LinkRequest[linkArgs=LinkArgs[dummyLink=false,disableSuffixSelector=false]],linkReferenceInvalid=false]",
         underTest.toString());
   }
 

--- a/src/test/java/io/wcm/handler/link/type/InternalLinkTypeTest.java
+++ b/src/test/java/io/wcm/handler/link/type/InternalLinkTypeTest.java
@@ -420,6 +420,9 @@ class InternalLinkTypeTest {
 
     assertEquals("/content/unittest/de_test/brand/de/section/content.sel1.suffix.htx/suf1/suf2.htx",
         linkHandler.get(targetPage).selectors("sel1").extension(FileExtension.HTML_UNCACHED).suffix("suf1/suf2").urlMode(UrlModes.NO_HOSTNAME).buildUrl());
+
+    assertEquals("http://www.dummysite.org/content/unittest/de_test/brand/de/section/content.sel1.html/suf1/suf2.html",
+        linkHandler.get(targetPage).selectors("sel1").suffix("suf1/suf2").disableSuffixSelector(true).buildUrl());
   }
 
   @Test


### PR DESCRIPTION
Although recommended as best practice, this can be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk for file name clashes in dispatcher cache.

Depends on https://github.com/wcm-io/io.wcm.handler.url/pull/3