### PR TITLE
LinkHandler: Build anchor markup on-demand

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -35,6 +35,9 @@
         LinkType: Mark getEditComponentResourceType and hasRichTextPlugin to be ignored in JSON representation.
       </action>
       <action type="update" dev="sseifert">
+        LinkHandler: Build anchor markup on-demand based on the current status of link when the anchor is requested. This allows to react on results of link post processors, and avoids building the anchor if not required.
+      </action>
+      <action type="update" dev="sseifert">
         Switch to AEM 6.5.7 as minimum version.
       </action>
     </release>

--- a/src/main/java/io/wcm/handler/link/Link.java
+++ b/src/main/java/io/wcm/handler/link/Link.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -54,6 +55,7 @@ public final class Link {
   private @NotNull LinkRequest linkRequest;
   private boolean linkReferenceInvalid;
   private Anchor anchor;
+  private Function<Link, Anchor> anchorBuilder;
   private String url;
   private Page targetPage;
   private Asset targetAsset;
@@ -113,6 +115,10 @@ public final class Link {
    */
   @JsonIgnore
   public Anchor getAnchor() {
+    if (this.anchor == null && this.anchorBuilder != null) {
+      this.anchor = this.anchorBuilder.apply(this);
+      this.anchorBuilder = null;
+    }
     return this.anchor;
   }
 
@@ -122,11 +128,12 @@ public final class Link {
   @JsonIgnore
   @SuppressWarnings("java:S1168")
   public Map<String, String> getAnchorAttributes() {
-    if (getAnchor() == null) {
+    Anchor a = getAnchor();
+    if (a == null) {
       return null;
     }
     Map<String, String> attributes = new HashMap<>();
-    for (Attribute attribute : getAnchor().getAttributes()) {
+    for (Attribute attribute : a.getAttributes()) {
       attributes.put(attribute.getName(), attribute.getValue());
     }
     return attributes;
@@ -140,12 +147,20 @@ public final class Link {
   }
 
   /**
+   * @param anchorBuilder Function that builds an anchor representation on demand
+   */
+  public void setAnchorBuilder(Function<Link, Anchor> anchorBuilder) {
+    this.anchorBuilder = anchorBuilder;
+  }
+
+  /**
    * @return Link markup (only the opening anchor tag) or null if resolving was not successful.
    */
   @JsonIgnore
   public String getMarkup() {
-    if (this.anchor != null) {
-      return StringUtils.removeEnd(this.anchor.toString(), "</a>");
+    Anchor a = getAnchor();
+    if (a != null) {
+      return StringUtils.removeEnd(a.toString(), "</a>");
     }
     else {
       return null;

--- a/src/main/java/io/wcm/handler/link/impl/LinkHandlerImpl.java
+++ b/src/main/java/io/wcm/handler/link/impl/LinkHandlerImpl.java
@@ -144,13 +144,15 @@ public final class LinkHandlerImpl implements LinkHandler {
     // generate markup (if markup builder is available) - first accepting wins
     List<Class<? extends LinkMarkupBuilder>> linkMarkupBuilders = linkHandlerConfig.getMarkupBuilders();
     if (linkMarkupBuilders != null) {
-      for (Class<? extends LinkMarkupBuilder> linkMarkupBuilderClass : linkMarkupBuilders) {
-        LinkMarkupBuilder linkMarkupBuilder = AdaptTo.notNull(adaptable, linkMarkupBuilderClass);
-        if (linkMarkupBuilder.accepts(link)) {
-          link.setAnchor(linkMarkupBuilder.build(link));
-          break;
+      link.setAnchorBuilder(l -> {
+        for (Class<? extends LinkMarkupBuilder> linkMarkupBuilderClass : linkMarkupBuilders) {
+          LinkMarkupBuilder linkMarkupBuilder = AdaptTo.notNull(adaptable, linkMarkupBuilderClass);
+          if (linkMarkupBuilder.accepts(l)) {
+            return linkMarkupBuilder.build(l);
+          }
         }
-      }
+        return null;
+      });
     }
 
     // postprocess link after resolving

--- a/src/test/java/io/wcm/handler/link/LinkTest.java
+++ b/src/test/java/io/wcm/handler/link/LinkTest.java
@@ -79,6 +79,19 @@ class LinkTest {
   }
 
   @Test
+  void testAnchorBuilder() {
+    assertNull(underTest.getAnchorAttributes());
+    assertNull(underTest.getMarkup());
+
+    underTest.setAnchorBuilder(l -> new Anchor(l.getUrl()).setTitle("title1"));
+    underTest.setUrl("http://dummy1");
+
+    assertEquals("title1", underTest.getAnchor().getTitle());
+    assertEquals("http://dummy1", underTest.getAnchorAttributes().get("href"));
+    assertEquals("<a href=\"http://dummy1\" title=\"title1\">", underTest.getMarkup());
+  }
+
+  @Test
   void testUrlAndValid() {
     assertFalse(underTest.isValid());
     underTest.setUrl("http://dummy");

--- a/src/test/java/io/wcm/handler/link/impl/LinkHandlerImplTest.java
+++ b/src/test/java/io/wcm/handler/link/impl/LinkHandlerImplTest.java
@@ -108,7 +108,7 @@ class LinkHandlerImplTest {
     assertEquals(true, link.isValid());
     assertEquals("http://xyz/path1/pre1/post1", link.getUrl());
     assertNotNull(link.getAnchor());
-    assertEquals("http://xyz/path1/pre1", link.getAnchor().getHRef());
+    assertEquals("http://xyz/path1/pre1/post1", link.getAnchor().getHRef());
   }
 
   @Test
@@ -138,7 +138,7 @@ class LinkHandlerImplTest {
     assertEquals(true, link.isValid());
     assertEquals("http://xyz/fallbackpath1/post1", link.getUrl());
     assertNotNull(link.getAnchor());
-    assertEquals(ImmutableMap.of("href", "http://xyz/fallbackpath1", "target", "_blank"), link.getAnchorAttributes());
+    assertEquals(ImmutableMap.of("href", "http://xyz/fallbackpath1/post1", "target", "_blank"), link.getAnchorAttributes());
   }
 
   @Test
@@ -158,7 +158,7 @@ class LinkHandlerImplTest {
     assertEquals(true, link.isValid());
     assertEquals("http://xyz/fallbackpath1/post1", link.getUrl());
     assertNotNull(link.getAnchor());
-    assertEquals(ImmutableMap.of("href", "http://xyz/fallbackpath1"), link.getAnchorAttributes());
+    assertEquals(ImmutableMap.of("href", "http://xyz/fallbackpath1/post1"), link.getAnchorAttributes());
   }
 
   @Test
@@ -180,7 +180,7 @@ class LinkHandlerImplTest {
     assertEquals(true, link.isValid());
     assertEquals("http://xyz/path1/pre1/post1", link.getUrl());
     assertNotNull(link.getAnchor());
-    assertEquals("http://xyz/path1/pre1", link.getAnchor().getHRef());
+    assertEquals("http://xyz/path1/pre1/post1", link.getAnchor().getHRef());
   }
 
   @Test


### PR DESCRIPTION
Build anchor markup on-demand based on the current status of link when the anchor is requested.
This allows to react on results of link post processors, and avoids building the anchor if not required.