### PR TITLE
Support detecting redirect pages using AEM cq:redirectTarget property

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="2.2.0" date="not released">
+      <action type="add" dev="sseifert">
+        Support detecting redirect pages using AEM cq:redirectTarget property (instead of link handler properties).
+      </action>
+    </release>
+
     <release version="2.1.0" date="2024-03-21">
       <action type="add" dev="royteeuwen" issue="13">
         Add optional support for using vanity paths when building link URLs to AEM pages.

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
   <body>
 
     <release version="2.2.0" date="not released">
-      <action type="add" dev="sseifert">
+      <action type="add" dev="sseifert" issue="14">
         Support detecting redirect pages using AEM cq:redirectTarget property (instead of link handler properties).
       </action>
     </release>

--- a/src/main/java/io/wcm/handler/link/spi/LinkHandlerConfig.java
+++ b/src/main/java/io/wcm/handler/link/spi/LinkHandlerConfig.java
@@ -19,6 +19,8 @@
  */
 package io.wcm.handler.link.spi;
 
+import static com.day.cq.wcm.api.NameConstants.PN_REDIRECT_TARGET;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -62,7 +64,7 @@ public abstract class LinkHandlerConfig implements ContextAwareService {
   private static final List<Class<? extends LinkProcessor>> DEFAULT_POST_PROCESSORS = List.of(
       DefaultInternalLinkInheritUrlParamLinkPostProcessor.class);
 
-  private static final String REDIRECT_RESOURCE_TYPE = "wcm-io/handler/link/components/page/redirect";
+  static final String REDIRECT_RESOURCE_TYPE = "wcm-io/handler/link/components/page/redirect";
 
   /**
    * Default content root path.
@@ -123,7 +125,8 @@ public abstract class LinkHandlerConfig implements ContextAwareService {
    * @return true if Page is a redirect page
    */
   public boolean isRedirect(@NotNull Page page) {
-    return ResourceType.is(page.getContentResource(), REDIRECT_RESOURCE_TYPE);
+    return ResourceType.is(page.getContentResource(), REDIRECT_RESOURCE_TYPE)
+        || StringUtils.isNotBlank(page.getProperties().get(PN_REDIRECT_TARGET, String.class));
   }
 
   /**

--- a/src/test/java/io/wcm/handler/link/spi/LinkHandlerConfigTest.java
+++ b/src/test/java/io/wcm/handler/link/spi/LinkHandlerConfigTest.java
@@ -19,12 +19,16 @@
  */
 package io.wcm.handler.link.spi;
 
+import static com.day.cq.wcm.api.NameConstants.PN_REDIRECT_TARGET;
 import static io.wcm.handler.link.spi.LinkHandlerConfig.DEFAULT_ROOT_PATH_CONTENT;
 import static io.wcm.handler.link.spi.LinkHandlerConfig.DEFAULT_ROOT_PATH_MEDIA;
 import static io.wcm.handler.link.testcontext.AppAemContext.ROOTPATH_CONTENT;
 import static io.wcm.handler.link.testcontext.AppAemContext.ROOTPATH_CONTENT_OTHER_SITE;
+import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,6 +91,15 @@ class LinkHandlerConfigTest {
   @Test
   void testGetLinkRootPath_Invalid() {
     assertNull(underTest.getLinkRootPath(contentPage, "invalid"));
+  }
+
+  @Test
+  void testIsRedirect() {
+    assertFalse(underTest.isRedirect(context.create().page(ROOTPATH_CONTENT + "/page1")));
+    assertTrue(underTest.isRedirect(context.create().page(ROOTPATH_CONTENT + "/page2", null,
+        PROPERTY_RESOURCE_TYPE, LinkHandlerConfig.REDIRECT_RESOURCE_TYPE)));
+    assertTrue(underTest.isRedirect(context.create().page(ROOTPATH_CONTENT + "/page3", null,
+        PN_REDIRECT_TARGET, "https://myhost.com")));
   }
 
 }

--- a/src/test/java/io/wcm/handler/link/testcontext/DummyLinkHandlerConfig.java
+++ b/src/test/java/io/wcm/handler/link/testcontext/DummyLinkHandlerConfig.java
@@ -66,7 +66,11 @@ public class DummyLinkHandlerConfig extends LinkHandlerConfig {
   @Override
   public boolean isRedirect(Page page) {
     String templatePath = page.getProperties().get(NameConstants.PN_TEMPLATE, String.class);
-    return StringUtils.equals(templatePath, DummyAppTemplate.REDIRECT.getTemplatePath());
+    boolean isRedirect = StringUtils.equals(templatePath, DummyAppTemplate.REDIRECT.getTemplatePath());
+    if (isRedirect) {
+      return true;
+    }
+    return super.isRedirect(page);
   }
 
 }

--- a/src/test/java/io/wcm/handler/link/type/InternalLinkTypeTest.java
+++ b/src/test/java/io/wcm/handler/link/type/InternalLinkTypeTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.WCMMode;
 
@@ -226,6 +227,25 @@ class InternalLinkTypeTest {
             .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
             .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
             .build());
+
+    Link link = linkHandler.get(redirectInternalPage).build();
+
+    assertTrue(link.isValid(), "link valid");
+    assertEquals("http://www.dummysite.org/content/unittest/de_test/brand/de/section/content.html", link.getUrl(), "link url");
+    assertNotNull(link.getAnchor(), "anchor");
+
+    List<Page> redirectPages = link.getRedirectPages();
+    assertEquals(1, redirectPages.size());
+    assertEquals(redirectInternalPage, redirectPages.get(0));
+  }
+
+  @Test
+  void testRedirectInternal_cqRedirectTarget() throws Exception {
+    LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
+
+    // redirect page using cq:redirectTarget property
+    Page redirectInternalPage = context.create().page("/content/unittest/de_test/brand/de/section/redirectInternal", null,
+        NameConstants.PN_REDIRECT_TARGET, targetPage.getPath());
 
     Link link = linkHandler.get(redirectInternalPage).build();
 


### PR DESCRIPTION
Support detecting redirect pages using AEM `cq:redirectTarget` property (instead of link handler properties)
If link handler properties (with `linkType`) are present, they have precedence over a `cq:redirectTarget` property.

to enable it, you might have to extend your `LinkHandlerConfig` implementation to support either specific redirect template, or any page with a `cq:redirectTarget` property set. example: https://github.com/wcm-io/aem-guides-wknd-wcmio/blob/79093d111d1cb9ffd80d56d6a922d43ac3563eac/core/src/main/java/com/adobe/aem/guides/wknd/core/config/impl/LinkHandlerConfigImpl.java#L45-L48