### PR TITLE
GraniteUI validator: Use data-foundation-validation instead of data-validation HTML attribute

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="2.2.4" date="not released">
+      <action type="fix" dev="sseifert">
+        GraniteUI validator: Use data-foundation-validation instead of data-validation HTML attribute, the latter is deprecated.
+      </action>
+    </release>
+
     <release version="2.2.2" date="2024-07-08">
       <action type="update" dev="sseifert" issue="15">
         Provide DEBUG/TRACE log messages for link processing.

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
   <body>
 
     <release version="2.2.4" date="not released">
-      <action type="fix" dev="sseifert">
+      <action type="fix" dev="sseifert" issue="17">
         GraniteUI validator: Use data-foundation-validation instead of data-validation HTML attribute, the latter is deprecated.
       </action>
     </release>

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/validation.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/validation.js
@@ -38,7 +38,7 @@
 
   // predefined "url" pattern validator
   foundationValidator.register('foundation.validation.validator', {
-    selector: '[data-validation="wcmio.handler.link.url"]',
+    selector: '[data-foundation-validation="wcmio.handler.link.url"]',
     validate: function(el) {
       var value = getValue(el);
       var valid = value.length === 0 || pattern.url.test(value);


### PR DESCRIPTION
Use `data-foundation-validation` instead of `data-validation` HTML attribute, the latter is deprecated.