### PR TITLE
Avoid NPE when page has no content because it is published implicitly

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.2.10" date="not-released">
+      <action type="fix" dev="mrozati" issue="31">
+        SeoSitemapExternalizer: fix NPE when page is published implicitly and jcr:content is missing.
+      </action>
+    </release>
+
     <release version="2.2.8" date="2025-07-28">
       <action type="add" dev="henrykuijpers" issue="26">
         I18n: Add Dutch translations.

--- a/src/main/java/io/wcm/handler/link/impl/SeoSitemapLinkExternalizerImpl.java
+++ b/src/main/java/io/wcm/handler/link/impl/SeoSitemapLinkExternalizerImpl.java
@@ -136,7 +136,7 @@ public class SeoSitemapLinkExternalizerImpl implements SitemapLinkExternalizer {
   }
 
   private @Nullable String externalizePageLink(@Nullable Page page) {
-    if (page != null) {
+    if (page != null && page.hasContent()) {
       LinkHandler linkHandler = AdaptTo.notNull(page.getContentResource(), LinkHandler.class);
       String url = linkHandler.get(page).urlMode(UrlModes.FULL_URL).buildUrl();
       if (url != null) {

--- a/src/test/java/io/wcm/handler/link/impl/SeoSitemapLinkExternalizerImplTest.java
+++ b/src/test/java/io/wcm/handler/link/impl/SeoSitemapLinkExternalizerImplTest.java
@@ -113,6 +113,23 @@ class SeoSitemapLinkExternalizerImplTest {
   }
 
   @Test
+  void testExternalizeResource_Page_NoContentResource() {
+    MockContextAwareConfig.writeConfiguration(context, ROOTPATH_CONTENT, SiteConfig.class,
+        "siteUrl", "https://myhost");
+
+    // When a page is published implicitly i.e. when it's child is published but the page itself not,
+    // AEM creates a page node without jcr:content
+    Resource resource = context.create().resource(ROOTPATH_CONTENT + "/page2", "jcr:primaryType", "cq:Page");
+
+    when(aemSitemapLinkExternalizer.externalize(resource)).thenReturn("defaultResult");
+
+    String result = underTest.externalize(resource);
+    assertEquals("defaultResult", result);
+
+    verifyNoMoreInteractions(aemSitemapLinkExternalizer);
+  }
+
+  @Test
   void testExternalizeResource_NotPage() {
     Resource resource = context.create().resource("/content/resource1");
 


### PR DESCRIPTION
fixes #31